### PR TITLE
Changed community URL in autostart to current community site

### DIFF
--- a/cbpp-configs/data/etc/skel/.config/openbox/autostart
+++ b/cbpp-configs/data/etc/skel/.config/openbox/autostart
@@ -13,7 +13,7 @@
 ##
 ## If you do something cool with your autostart script and you think others
 ## could benefit from your hack, please consider sharing it at:
-## http://crunchbang.org/forums/
+## https://www.reddit.com/r/crunchbangplusplus
 ##
 ## Have fun & happy CrunchBangin'! :)
 


### PR DESCRIPTION
I noticed in the /etc/skel/.config/openbox/autostart file, there is a mention to the old Crunchbang forums. I wasn't sure if this was intentional, so I've updated the autostart file to contain a reference to the community link in the crunchbangplusplus.org website instead. If you agree, you may pull this in at your discretion.
