### PR TITLE
Conky url

### DIFF
--- a/cbpp-configs/data/etc/skel/.config/openbox/menu.xml
+++ b/cbpp-configs/data/etc/skel/.config/openbox/menu.xml
@@ -341,7 +341,7 @@
 					<execute>mate-power-preferences</execute>
 				</action>
 			</item>
-			<item label="NewScreensaver">
+			<item label="Screensaver">
 				<action name="Execute">
 					<execute>xscreensaver-demo</execute>
 				</action>

--- a/cbpp-configs/data/etc/skel/.conkyrc
+++ b/cbpp-configs/data/etc/skel/.conkyrc
@@ -5,10 +5,10 @@
 # Check http://conky.sf.net for an up-to-date-list.
 #
 # For ideas about how to modify conky, please see:
-# http://crunchbanglinux.org/forums/topic/59/my-conky-config/
+# http://conky.sourceforge.net/variables.html
 #
 # For help with conky, please see:
-# http://crunchbanglinux.org/forums/topic/2047/conky-help/
+# http://conky.sourceforge.net/documentation.html
 #
 # Enjoy! :)
 ##############################################


### PR DESCRIPTION
The following URL's are contained in the default .conkyrc, but they 404:

http://crunchbanglinux.org/forums/topic/59/my-conky-config/
http://crunchbanglinux.org/forums/topic/2047/conky-help/

I changed those URLs to sites within the official conky documentation.
