### PR TITLE
Tint2rc url

### DIFF
--- a/cbpp-configs/data/etc/skel/.config/openbox/menu.xml
+++ b/cbpp-configs/data/etc/skel/.config/openbox/menu.xml
@@ -341,7 +341,7 @@
 					<execute>mate-power-preferences</execute>
 				</action>
 			</item>
-			<item label="NewScreensaver">
+			<item label="Screensaver">
 				<action name="Execute">
 					<execute>xscreensaver-demo</execute>
 				</action>

--- a/cbpp-configs/data/etc/skel/.config/tint2/tint2rc
+++ b/cbpp-configs/data/etc/skel/.config/tint2/tint2rc
@@ -4,8 +4,8 @@
 # For more information about tint2, see:
 # http://code.google.com/p/tint2/wiki/Welcome
 #
-# For more config file examples, see:
-# http://crunchbanglinux.org/forums/topic/3232/my-tint2-config/
+# For more info on configuring tint2, see:
+# https://code.google.com/p/tint2/wiki/Configure
 
 # Background definitions
 # ID 1


### PR DESCRIPTION
I found another URL in one of the configs that results in a 404.
The following URL is no longer valid:
http://crunchbanglinux.org/forums/topic/3232/my-tint2-config/
