### PR TITLE
Switch menu.xml Power Management to xfce4-power-management-settings

### DIFF
--- a/cbpp-configs/data/etc/skel/.config/openbox/menu.xml
+++ b/cbpp-configs/data/etc/skel/.config/openbox/menu.xml
@@ -338,7 +338,7 @@
 			</item>
 			<item label="Power Management">
 				<action name="Execute">
-					<execute>mate-power-preferences</execute>
+					<execute>xfce4-power-manager-settings</execute>
 				</action>
 			</item>
 			<item label="Screensaver">


### PR DESCRIPTION
Openbox menu was using mate-power-preferences, but it does not exist on system.  xfce4-power-manager-settings is being used by the power icon on the taskbar, so switched the Power Management entry to execute xfce4-power-manager-settings instead.